### PR TITLE
move rtpSpawn and RTP_ID_ERROR from libstd to libc

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -968,6 +968,7 @@ pub const SEEK_END: ::c_int = 2;
 
 // rtpLibCommon.h
 pub const VX_RTP_NAME_LENGTH: usize = 255;
+pub const RTP_ID_ERROR: ::RTP_ID = -1;
 
 // h/public/unistd.h
 pub const _SC_GETPW_R_SIZE_MAX: ::c_int = 21; // Via unistd.h
@@ -2050,6 +2051,15 @@ extern "C" {
 
     // rtpLibCommon.h
     pub fn rtpInfoGet(rtpId: ::RTP_ID, rtpStruct: *mut ::RTP_DESC) -> ::c_int;
+    pub fn rtpSpawn(
+        pubrtpFileName: *const ::c_char,
+        argv: *const *const ::c_char,
+        envp: *const *const ::c_char,
+        priority: ::c_int,
+        uStackSize: ::size_t,
+        options: ::c_int,
+        taskOptions: ::c_int,
+    ) -> RTP_ID;
 
     // ioLib.h
     pub fn _realpath(


### PR DESCRIPTION
r? @n-salim 