### PR TITLE
We don't support RTLD_DEFAULT in VxWorks .

### DIFF
--- a/src/vxworks/mod.rs
+++ b/src/vxworks/mod.rs
@@ -550,10 +550,6 @@ pub const EAI_SERVICE: ::c_int = 9;
 pub const EAI_SOCKTYPE: ::c_int = 10;
 pub const EAI_SYSTEM: ::c_int = 11;
 
-// This is not defined in vxWorks, but we have to define it here
-// to make the building pass for getrandom and libstd, FIXME
-pub const RTLD_DEFAULT: *mut ::c_void = 0i64 as *mut ::c_void;
-
 //Clock Lib Stuff
 pub const CLOCK_REALTIME: ::c_int = 0x0;
 pub const CLOCK_MONOTONIC: ::c_int = 0x1;


### PR DESCRIPTION
Used on Unix to support multiple versions of the OS. Not used yet in the VxWorks
implementation. And relies on dlsym, not a suitable solution for VxWorks.